### PR TITLE
Fix directories used for testing

### DIFF
--- a/maildir_test.go
+++ b/maildir_test.go
@@ -62,13 +62,13 @@ func makeDelivery(tb testing.TB, d Dir, msg string) {
 func TestInit(t *testing.T) {
 	t.Parallel()
 
-	var d Dir = "test_create"
+	var d Dir = "test_init"
 	err := d.Init()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := os.Open("test_create")
+	f, err := os.Open("test_init")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I presume this is a leftover from when `Init()` was named `Create()`.

Both functions `TestInit()` and `TestDir_Create` used the `test_create` dir, which lead to race conditions in testing.

AFAICT they're fixed after renaming.