### PR TITLE
Add RemoveDir

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -413,6 +413,14 @@ func (d Dir) Remove(key string) error {
 	return os.Remove(f)
 }
 
+// RemoveDir removes the maildir, including any files within.
+//
+// This removes the maildir completely.
+// To re-create the maildir, use `Init`.
+func (d Dir) RemoveDir() error {
+	return os.RemoveAll(string(d))
+}
+
 // Clean removes old files from tmp and should be run periodically.
 // This does not use access time but modification time for portability reasons.
 func (d Dir) Clean() error {

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -103,6 +103,32 @@ func TestInit(t *testing.T) {
 	defer cleanup(t, d)
 }
 
+func TestRemoveDir(t *testing.T) {
+	t.Parallel()
+
+	var d Dir = "test_remove_dir"
+	if err := d.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Open("test_remove_dir"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.RemoveDir(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Open("test_remove_dir"); err != nil {
+		// Expecting a "does not exist" error
+		if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+	} else {
+		t.Fatal(fmt.Errorf("Directory was not removed upon RemoveDir()!"))
+	}
+}
+
 func TestDelivery(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This adds a simple `RemoveDir()` function to completely delete a
maildir, along with a (also simple) test for it.