### PR TITLE
fix for dir.Filename(key) on mailbox name using square brackets

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -216,24 +216,22 @@ func (d Dir) Filename(key string) (string, error) {
 
 	// search for a valid candidate (in blocks of readdirChunk)
 	for {
-		var names []string
-		names, err = file.Readdirnames(readdirChunk)
+		names, err := file.Readdirnames(readdirChunk)
+
+		// no match
+		if errors.Is(err, io.EOF) {
+			return "", &KeyError{key, 0}
+		}
+		if err != nil {
+			return "", err
+		}
 
 		for _, name := range names {
 			if strings.HasPrefix(name, key) {
 				return name, nil
 			}
 		}
-		if err != nil {
-			break
-		}
 	}
-	if err != nil && !errors.Is(err, io.EOF) {
-		return "", err
-	}
-	// no match
-	return "", &KeyError{key, 0}
-
 }
 
 // Open reads a message by key.

--- a/maildir.go
+++ b/maildir.go
@@ -344,7 +344,7 @@ func newKey() (string, error) {
 	key += host
 	key += "."
 	key += strconv.FormatInt(int64(os.Getpid()), 10)
-	key += strconv.FormatInt(atomic.LoadInt64(&id), 10)
+	key += strconv.FormatInt(id, 10)
 	atomic.AddInt64(&id, 1)
 	bs := make([]byte, 10)
 	_, err = io.ReadFull(rand.Reader, bs)

--- a/maildir.go
+++ b/maildir.go
@@ -9,6 +9,7 @@ package maildir
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,6 +25,10 @@ import (
 // This should only be changed on operating systems where the colon isn't
 // allowed in filenames.
 var separator rune = ':'
+
+// readdirChunk represents the number of files to load at once from the mailbox
+// when searching for a message
+var readdirChunk = 100
 
 var id int64 = 10000
 
@@ -203,14 +208,32 @@ func (d Dir) Filename(key string) (string, error) {
 			return guess, nil
 		}
 	}
-	matches, err := filepath.Glob(filepath.Join(string(d), "cur", key+"*"))
+	file, err := os.Open(filepath.Join(string(d), "cur"))
 	if err != nil {
 		return "", err
 	}
-	if n := len(matches); n != 1 {
-		return "", &KeyError{key, n}
+	defer file.Close()
+
+	// search for a valid candidate (in blocks of readdirChunk)
+	for {
+		var names []string
+		names, err = file.Readdirnames(readdirChunk)
+
+		for _, name := range names {
+			if strings.HasPrefix(name, key) {
+				return name, nil
+			}
+		}
+		if err != nil {
+			break
+		}
 	}
-	return matches[0], nil
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	// no match
+	return "", &KeyError{key, 0}
+
 }
 
 // Open reads a message by key.
@@ -321,7 +344,7 @@ func newKey() (string, error) {
 	key += host
 	key += "."
 	key += strconv.FormatInt(int64(os.Getpid()), 10)
-	key += strconv.FormatInt(id, 10)
+	key += strconv.FormatInt(atomic.LoadInt64(&id), 10)
 	atomic.AddInt64(&id, 1)
 	bs := make([]byte, 10)
 	_, err = io.ReadFull(rand.Reader, bs)

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -392,6 +392,10 @@ func TestDifferentSizesOfReaddirChunks(t *testing.T) {
 	}
 
 	previousReaddirChunk := readdirChunk
+	// set it back to normal for the following tests
+	defer func() {
+		readdirChunk = previousReaddirChunk
+	}()
 
 	// try different sizes of chunks
 	for chunkSize := 0; chunkSize <= totalFiles+1; chunkSize++ {
@@ -406,8 +410,6 @@ func TestDifferentSizesOfReaddirChunks(t *testing.T) {
 			}
 		}
 	}
-	// set it back to normal for the following tests
-	readdirChunk = previousReaddirChunk
 }
 
 func BenchmarkFilename(b *testing.B) {

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -328,6 +329,85 @@ func TestIllegal(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+}
+
+func TestFolderWithSquareBrackets(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	name := "[Google Mail].All Mail"
+
+	dir := Dir(filepath.Join(root, name))
+	if err := dir.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	key := func() string {
+		key, writer, err := dir.Create([]Flag{FlagPassed, FlagReplied})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer writer.Close()
+		_, err = writer.Write([]byte("this is a message"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return key
+	}()
+
+	filename, err := dir.Filename(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filename == "" {
+		t.Error("filename should not be empty")
+	}
+}
+
+func TestDifferentSizesOfReaddirChunks(t *testing.T) {
+	totalFiles := 3
+	// don't run this test in // as it modifies a package variable
+	source := t.TempDir()
+
+	dir := Dir(source)
+	if err := dir.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < totalFiles; i++ {
+		makeDelivery(t, dir, fmt.Sprintf("here is message number %d", i))
+	}
+
+	// grab keys
+	keys, err := dir.Unseen()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// avoid the filename guesser
+	for _, key := range keys {
+		err := dir.SetFlags(key, []Flag{FlagPassed, FlagReplied})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	previousReaddirChunk := readdirChunk
+
+	// try different sizes of chunks
+	for chunkSize := 0; chunkSize <= totalFiles+1; chunkSize++ {
+		readdirChunk = chunkSize
+		for _, key := range keys {
+			filename, err := dir.Filename(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if filename == "" {
+				t.Errorf("cannot find filename for key %q", key)
+			}
+		}
+	}
+	// set it back to normal for the following tests
+	readdirChunk = previousReaddirChunk
 }
 
 func BenchmarkFilename(b *testing.B) {


### PR DESCRIPTION
This is a PR to replace `filepath.Glob()` by `file.Readdirnames()` in `dir.Filename()` implementation.

It is worth noting:
- it read files per chunks of 100 (in case the mailbox is very large)
- it **stops** at the first match. This is a breaking change from the previous version which was returning an error with the number of matches (I can change the code if you prefer keeping the original behaviour)


