### PR TITLE
Use a semicolon for the separator on windows

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -19,11 +19,6 @@ import (
 	"time"
 )
 
-// The separator separates a messages unique key from its flags in the filename.
-// This should only be changed on operating systems where the colon isn't
-// allowed in filenames.
-const separator rune = ':'
-
 // readdirChunk represents the number of files to load at once from the mailbox
 // when searching for a message
 var readdirChunk = 100

--- a/maildir_notwindows.go
+++ b/maildir_notwindows.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package maildir
+
+// The separator separates a messages unique key from its flags in the filename.
+// This should only be changed on operating systems where the colon isn't
+// allowed in filenames.
+const separator rune = ':'

--- a/maildir_windows.go
+++ b/maildir_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package maildir
+
+// The separator separates a messages unique key from its flags in the filename.
+// This should only be changed on operating systems where the colon isn't
+// allowed in filenames.
+const separator rune = ';'


### PR DESCRIPTION
Windows does not support colons in filenames, so the colon separator does not work. This PR changes the separator to a semicolon on Windows and keeps it the same on other platforms. A semicolon is a frequently used alternative to the colon for the Maildir separator on Windows (see https://en.wikipedia.org/wiki/Maildir#File-system_compatibility_issues and https://marc.info/?l=mutt-users&m=131644437917477&w=2).