### PR TITLE
fix: flags should only come from file basename

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -285,7 +285,7 @@ func (d Dir) Flags(key string) ([]Flag, error) {
 	if err != nil {
 		return nil, err
 	}
-	split := strings.FieldsFunc(filename, func(r rune) bool {
+	split := strings.FieldsFunc(filepath.Base(filename), func(r rune) bool {
 		return r == separator
 	})
 	switch {


### PR DESCRIPTION
hi Simon!

currently the full path is split to extract the flags, which is not desirable when the file path has : characters in it

for example in this case, where the path to the maildir includes a folder named `a:b`. this means `split[1]` contains a chunk of the path that it shouldn't: https://files.george.honeywood.org.uk/2024-01-06-aerc-debug.png

I'm not very familiar with maildirs, so there may be implications that I don't understand here. I came across this issue in aerc, where I couldn't read mail from a timestamped zfs snapshot, because of the colon characters in the path.

let me know if this seems reasonable!
George