### PR TITLE
fix(maildir): Init, handle directory with subpaths

### DIFF
--- a/maildir.go
+++ b/maildir.go
@@ -476,7 +476,7 @@ func (d Dir) Init() error {
 		filepath.Join(string(d), "cur"),
 	}
 	for _, name := range dirnames {
-		if err := os.Mkdir(name, 0700); err != nil && !os.IsExist(err) {
+		if err := os.MkdirAll(name, 0700); err != nil && !os.IsExist(err) {
 			return err
 		}
 	}

--- a/maildir_test.go
+++ b/maildir_test.go
@@ -65,13 +65,13 @@ func makeDelivery(tb testing.TB, d Dir, msg string) {
 func TestInit(t *testing.T) {
 	t.Parallel()
 
-	var d Dir = "test_init"
+	var d Dir = "parent_dir/test_init"
 	err := d.Init()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	f, err := os.Open("test_init")
+	f, err := os.Open("parent_dir/test_init")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
e.g. before the following code would return an error:

	var d Dir = "parent_dir/test_init"
	err := d.Init()
